### PR TITLE
fix gh-8 and resolve gh-1 with updated app compat logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ALT_EXES = chpst softlimit envdir pgrphack setuidgid envuidgid setlock
 
 .PHONY: all clean install
 
-all: $(name) $(ALT_EXES)
+all: $(name) $(ALT_EXES) chpst.compat
 
 -include $(DEP)
 
@@ -34,11 +34,19 @@ $(name): $(OBJS)
 $(ALT_EXES): $(name)
 	$(LN) $< $@
 
+# chpst.compat is a build of 'chpst' that does not accept xchpst extensions
+chpst.compat: chpst.o $(filter-out xchpst.o,$(OBJS))
+	$(LINK.o) $^ $(LOADLIBES) $(LDLIBS) -o $@
+
+chpst.o: xchpst.c
+	$(COMPILE.c) $(OUTPUT_OPTION) -DPROG_DEFAULT=chpst -DSTRICT_CHPST_COMPAT $<
+
 clean:
-	$(RM) $(name) $(OBJS) $(DEP) $(ALT_EXES)
+	$(RM) $(name) $(OBJS) $(DEP) $(ALT_EXES) chpst.o chpst.compat
 
 install:
 	$(INSTALL) -m 755 -D -t $(DESTDIR)$(prefix)/bin               $(name)
 #	$(INSTALL) -m 755 -D -t $(DESTDIR)$(prefix)/bin               $(ALT_EXES)
+#	$(INSTALL) -m 755 -D -t $(DESTDIR)$(prefix)/bin               chpst.compat
 	$(INSTALL) -m 644 -D -t $(DESTDIR)$(prefix)/share/doc/$(name) xchpst-funcs.sh
 	$(INSTALL) -m 644 -D -t $(DESTDIR)$(prefix)/share/man/man8    $(name).8

--- a/options.h
+++ b/options.h
@@ -30,6 +30,7 @@ enum compat_level {
   COMPAT_SETLOCK   = 0200,
 };
 
+
 enum verbosity {
   LOG_LEVEL_NONE = 0,
   LOG_LEVEL_VERBOSE = 1,

--- a/xchpst.8
+++ b/xchpst.8
@@ -117,7 +117,7 @@ user.
 Drop the listed capabilities when dropping to a non-root
 user, but retain all others.
 .It Fl -no-new-privs
-Prevent the target application form obtaining any new privileges.
+Prevent the target application from obtaining any new privileges.
 See
 .Xr PR_SET_NO_NEW_PRIVS 2const .
 .It Fl -scheduler Ar other | batch | idle


### PR DESCRIPTION
1. Add a default app variable, defaulting to _xchpst_ compat level to fix #8.
2. Change compat for `chpst` invocation to be identical to `xchpst`, with _xchpst_ compat level, to resolve #1.
3. Build additional executable `chpst.compat` that defaults to _chpst_ compat and enforces strict compatibility, refusing _xchpst_ compat level options.